### PR TITLE
Connection error handling

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -46,51 +46,55 @@ fn initial_setup_for_client(stream: &mut TcpStream, message: &Msg) -> (bool, Str
 /// Collects input from the user and performs client IO.  Asks the user
 /// for input, translates the input into Msg data type, responds to server
 /// replies.
-/// Main functionality is split between "ingame" and "out of game" functions,
+/// Main functionality is split between "in game" and "out of game" functions,
 /// where the input and validation is different between whether the client
 /// is currently playing a game or currently in the "lobby"
 #[allow(unused_assignments)]
 pub fn run_client() {
-    let connection = initial_screen();
-    let mut buffer_arr = [0; 512];
-    let mut nickname: String = String::new();
-    let mut my_id: u32 = 0;
-    match TcpStream::connect(&connection) {
-        Ok(mut stream) => {
-            let mut cli_msg = initial_hello_msg();
-            let res_tuple = initial_setup_for_client(&mut stream, &cli_msg);
-            if !res_tuple.0 {
-                println!("Server terminated connection");
-                return;
-            }
-            nickname = res_tuple.1.clone();
-            my_id = res_tuple.2;
-            cli_msg = handle_out_of_game(&connection, &nickname);
-            loop {
-                cli_msg.serialize(&mut buffer_arr);
-                stream.write_all(&buffer_arr).expect("Server write error");
-                stream.flush().unwrap();
-                match stream.read(&mut buffer_arr) {
-                    Ok(size) => {
-                        if size == 0 {
-                            println!("Server terminated connection");
-                            break;
+    loop {
+        let connection = initial_screen();
+        let mut buffer_arr = [0; 512];
+        let mut nickname: String = String::new();
+        let mut my_id: u32 = 0;
+        match TcpStream::connect(&connection) {
+            Ok(mut stream) => {
+                let mut cli_msg = initial_hello_msg();
+                let res_tuple = initial_setup_for_client(&mut stream, &cli_msg);
+                if !res_tuple.0 {
+                    println!("Server terminated connection");
+                    return;
+                }
+                nickname = res_tuple.1.clone();
+                my_id = res_tuple.2;
+                cli_msg = handle_out_of_game(&connection, &nickname);
+                loop {
+                    cli_msg.serialize(&mut buffer_arr);
+                    stream.write_all(&buffer_arr).expect("Server write error");
+                    stream.flush().unwrap();
+                    match stream.read(&mut buffer_arr) {
+                        Ok(size) => {
+                            if size == 0 {
+                                println!("Server terminated connection");
+                                break;
+                            }
+                            let res_msg: Msg = bincode::deserialize(&buffer_arr[0..size]).unwrap();
+                            if res_msg.command == Commands::KillClient {
+                                break;
+                            }
+                            cli_msg =
+                                handle_server_response(&res_msg, &connection, &mut nickname, my_id);
                         }
-                        let res_msg: Msg = bincode::deserialize(&buffer_arr[0..size]).unwrap();
-                        if res_msg.command == Commands::KillClient {
-                            break;
+                        Err(_) => {
+                            println!("server did something bad");
                         }
-                        cli_msg =
-                            handle_server_response(&res_msg, &connection, &mut nickname, my_id);
-                    }
-                    Err(_) => {
-                        println!("server did something bad");
                     }
                 }
+                break;
             }
-        }
-        Err(e) => {
-            println!("Failed to connect: {}", e);
+            Err(e) => {
+                println!("Failed to connect: {}", e);
+                continue;
+            }
         }
     }
     println!("Connection terminated");

--- a/src/client_input_handler.rs
+++ b/src/client_input_handler.rs
@@ -7,17 +7,36 @@ use std::{thread, time};
 
 // --------------- out of game --------------- //
 
-/// Initial input screen.  Asks the client for a host and port
+/// Initial input screen.  Calls helper functions to get valid host and port
 /// to connect to.  Returns a connection string.
 pub fn initial_screen() -> String {
+    let host: String = get_host_input();
+    let port_int: u32 = get_port_input();
+
+    host.trim().to_string() + &":".to_string() + &port_int.to_string()
+}
+
+fn get_host_input() -> String {
     let stdin = io::stdin();
     let mut stdout = io::stdout();
     let mut host = String::new();
-    let port_int: u32;
+    loop {
+        print!("Enter a host: ");
+        stdout.flush().expect("Error flushing buffer");
+        stdin.read_line(&mut host).expect("Error reading in");
+        if host.trim().is_empty() {
+            println!("Cannot have an empty host!");
+            continue;
+        }
+        break;
+    }
+    host
+}
 
-    print!("Enter a host: ");
-    stdout.flush().expect("Error flushing buffer");
-    stdin.read_line(&mut host).expect("Error reading in");
+fn get_port_input() -> u32 {
+    let stdin = io::stdin();
+    let mut stdout = io::stdout();
+    let port_int: u32;
     loop {
         let mut port = String::new();
         print!("Enter a port: ");
@@ -34,8 +53,7 @@ pub fn initial_screen() -> String {
             }
         }
     }
-    let trimmed_host = host.trim().to_string();
-    trimmed_host + &":".to_string() + &port_int.to_string()
+    port_int
 }
 
 /// Returns the first message necessary for the client

--- a/src/client_input_handler.rs
+++ b/src/client_input_handler.rs
@@ -13,17 +13,27 @@ pub fn initial_screen() -> String {
     let stdin = io::stdin();
     let mut stdout = io::stdout();
     let mut host = String::new();
-    let mut port = String::new();
+    let port_int: u32;
+
     print!("Enter a host: ");
     stdout.flush().expect("Error flushing buffer");
     stdin.read_line(&mut host).expect("Error reading in");
-    print!("Enter a port: ");
-    stdout.flush().expect("Error flushing buffer");
-    stdin.read_line(&mut port).expect("Error reading in");
-    let port_int = port
-        .trim()
-        .parse::<u32>()
-        .expect("could not make port into an int");
+    loop {
+        let mut port = String::new();
+        print!("Enter a port: ");
+        stdout.flush().expect("Error flushing buffer");
+        stdin.read_line(&mut port).expect("Error reading in");
+        match port.trim().parse() {
+            Ok(x) => {
+                port_int = x;
+                break;
+            }
+            Err(e) => {
+                println!("could not make port into an int: {}!", e);
+                continue;
+            }
+        }
+    }
     let trimmed_host = host.trim().to_string();
     trimmed_host + &":".to_string() + &port_int.to_string()
 }

--- a/src/client_input_handler.rs
+++ b/src/client_input_handler.rs
@@ -126,16 +126,29 @@ fn list_active_users() -> Msg {
 fn join_game() -> Msg {
     let stdin = io::stdin();
     let mut stdout = io::stdout();
-    let mut game_id = String::new();
-    print!("Which Game Id do you want to join: ");
-    stdout.flush().expect("Client input something nonsensical");
-    stdin.read_line(&mut game_id).expect("I/O error");
+    let game_id: usize;
+    loop {
+        let mut game_id_input = String::new();
+        print!("Which Game ID do you want to join: ");
+        stdout.flush().expect("Client input something nonsensical");
+        stdin.read_line(&mut game_id_input).expect("I/O error");
+        match game_id_input.trim().parse() {
+            Ok(x) => {
+                game_id = x;
+                break;
+            }
+            Err(e) => {
+                println!("invalid integer + {}!", e);
+                continue;
+            }
+        }
+    }
     Msg {
         status: Status::Ok,
         headers: Headers::Write,
         command: Commands::JoinGame,
         game_status: GameStatus::NotInGame,
-        data: game_id.trim().to_string(),
+        data: game_id.to_string(),
         game_state: GameState::new_empty(),
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -66,7 +66,7 @@ fn handle_each_client_tcp_connection(
 }
 
 /// Data Management
-///     Thread spun from master process that allows for sharing of data.
+/// Thread spun from master process that allows for sharing of data.
 /// Game states are recorded as well as per-connection client information.
 /// Messages are received from the TCP connection manager and handled
 /// based on message content.  Responses are sent to TCP Connection Manager

--- a/src/server_input_handler.rs
+++ b/src/server_input_handler.rs
@@ -159,16 +159,36 @@ fn join_game(
     let mut game_list_unlocked = game_list_mutex.lock().unwrap();
     let mut id_game_map_unlocked = id_game_map_mutex.lock().unwrap();
     let game_id: usize = client_msg.data.parse().unwrap();
-    let game: &mut GameState = &mut game_list_unlocked[game_id];
-    game.add_player_two(client_id);
-    id_game_map_unlocked.insert(client_id, game.game_id);
-    Msg {
-        status: Status::Ok,
-        headers: Headers::Response,
-        command: Commands::JoinGame,
-        game_status: GameStatus::InGame,
-        data: format!("Joined Game {}", &game.game_name),
-        game_state: game.clone(),
+    if game_list_unlocked.len() == 0 {
+        Msg {
+            status: Status::Ok,
+            headers: Headers::Response,
+            command: Commands::JoinGame,
+            game_status: GameStatus::NotInGame,
+            data: "No active games available. Please start a new game to begin.".to_string(),
+            game_state: GameState::new_empty(),
+        }
+    } else if game_id > game_list_unlocked.len() - 1 {
+        Msg {
+            status: Status::Ok,
+            headers: Headers::Response,
+            command: Commands::JoinGame,
+            game_status: GameStatus::NotInGame,
+            data: "Invalid game id entered. View active game list for valid game id's".to_string(),
+            game_state: GameState::new_empty(),
+        }
+    } else {
+        let game: &mut GameState = &mut game_list_unlocked[game_id];
+        game.add_player_two(client_id);
+        id_game_map_unlocked.insert(client_id, game.game_id);
+        Msg {
+            status: Status::Ok,
+            headers: Headers::Response,
+            command: Commands::JoinGame,
+            game_status: GameStatus::InGame,
+            data: format!("Joined Game {}", &game.game_name),
+            game_state: game.clone(),
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #17. Re-prompting clients if connection was unsuccessful or if invalid input was entered for port (non-numerical)