### PR TITLE
Graceful disconnect

### DIFF
--- a/src/client_input_handler.rs
+++ b/src/client_input_handler.rs
@@ -111,7 +111,7 @@ pub fn handle_out_of_game(connection: &str, user_nick: &str) -> Msg {
                     return join_game();
                 }
                 6 => {
-                    return client_disconnect();
+                    return client_initiate_disconnect();
                 }
                 _ => {
                     println!("invalid selection");
@@ -221,8 +221,7 @@ pub fn start_new_game() -> Msg {
     }
 }
 
-fn client_disconnect() -> Msg {
-    print!("{}[2J", 27 as char);
+pub fn client_initiate_disconnect() -> Msg {
     Msg {
         status: Status::Ok,
         headers: Headers::Read,
@@ -418,7 +417,7 @@ fn render_board(board: &[u8; BOARD_LENGTH], am_i_player_one: bool) {
     };
 }
 
-fn leave_game() -> Msg {
+pub fn leave_game() -> Msg {
     Msg {
         status: Status::Ok,
         headers: Headers::Write,

--- a/src/game_objects.rs
+++ b/src/game_objects.rs
@@ -55,9 +55,31 @@ impl GameState {
         }
     }
 
-    pub fn add_player_two(&mut self, p_two: u32) {
-        self.player_two = p_two;
-        self.active = true;
+    pub fn add_new_player(&mut self, player_id: u32) {
+        if self.player_one == 0 {
+            self.player_one = player_id;
+        } else if self.player_two == 0 {
+            self.player_two = player_id;
+        }
+        if self.player_one != 0 && self.player_two != 0 {
+            self.active = true;
+        }
+    }
+
+    pub fn remove_player(&mut self, player_id: u32) {
+        if self.player_one == player_id {
+            self.player_one = 0;
+        } else if self.player_two == player_id {
+            self.player_two = 0;
+        }
+        if self.player_one == 0 || self.player_two == 0 {
+            let mut init_game_board = [STARTING_STONES; SLOTS * 2];
+            init_game_board[SLOTS] = 0;
+            init_game_board[0] = 0;
+            self.game_board = init_game_board;
+            self.active = false;
+        }
+        info!("Removed player {}, game is now: {:?}", player_id, self);
     }
 
     //noinspection ALL - don't have IDE warnings
@@ -181,14 +203,14 @@ fn test_game_state_init_values_are_correct() {
 fn test_game_becomes_active_after_adding_player_two() {
     let mut gs: GameState = GameState::new(1, "name".to_string(), 0);
     assert!(!gs.active);
-    gs.add_player_two(1);
+    gs.add_new_player(1);
     assert!(gs.active);
 }
 
 #[test]
 fn test_game_state_updates_after_one_move() {
     let mut gs: GameState = GameState::new(1, "name".to_string(), 0);
-    gs.add_player_two(1);
+    gs.add_new_player(1);
     let mut init_game_board = [STARTING_STONES; SLOTS * 2];
     init_game_board[SLOTS] = 0;
     init_game_board[0] = 0;
@@ -199,7 +221,7 @@ fn test_game_state_updates_after_one_move() {
 #[test]
 fn test_turn_changes_after_making_move() {
     let mut gs: GameState = GameState::new(1, "name".to_string(), 0);
-    gs.add_player_two(1);
+    gs.add_new_player(1);
     let turn1: bool = gs.player_one_turn;
     gs.make_move(1);
     let turn2: bool = gs.player_one_turn;
@@ -216,7 +238,7 @@ fn test_turn_changes_after_making_move() {
 #[test]
 fn test_scoring_turns_dont_change_players() {
     let mut gs: GameState = GameState::new(1, "name".to_string(), 0);
-    gs.add_player_two(1);
+    gs.add_new_player(1);
     let turn1: bool = gs.player_one_turn;
     gs.make_move(3);
     let turn2: bool = gs.player_one_turn;
@@ -227,7 +249,7 @@ fn test_scoring_turns_dont_change_players() {
 fn test_captures() {
     // this test assumes SLOTS = 7 and starting_stones = 4
     let mut gs: GameState = GameState::new(1, "name".to_string(), 0);
-    gs.add_player_two(1);
+    gs.add_new_player(1);
     gs.make_move(6);
     gs.make_move(11);
     let turn1: bool = gs.player_one_turn;
@@ -243,9 +265,9 @@ fn test_captures() {
 #[test]
 fn test_collect_remaining() {
     let mut gs: GameState = GameState::new(1, "name".to_string(), 0);
-    gs.add_player_two(1);
+    gs.add_new_player(1);
     let mut gs2: GameState = GameState::new(1, "name".to_string(), 0);
-    gs.add_player_two(1);
+    gs.add_new_player(1);
     gs.collect_remaining_stones();
     gs2.make_move(6);
     gs2.collect_remaining_stones();

--- a/src/server.rs
+++ b/src/server.rs
@@ -38,7 +38,7 @@ fn handle_client_disconnect(
     boot_msgs.push(client_initiate_disconnect());
     for msg in boot_msgs {
         snd_channel.lock().unwrap().send((user_id, msg)).unwrap();
-        let res = rec_channel.recv().expect("something wrong");
+        rec_channel.recv().expect("something wrong");
     }
 }
 
@@ -192,7 +192,7 @@ fn tcp_connection_manager(
                     .spawn(move || {
                         handle_each_client_tcp_connection(stream, &channels.0, &channels.1, cur_id);
                     })
-                    .expect(format!("Error spawning thread for client id: {}", cur_id).as_ref());
+                    .unwrap_or_else(|_| panic!("Error spawning thread for client id: {}", cur_id));
                 cur_id += 1;
             }
             Err(e) => {

--- a/src/server_input_handler.rs
+++ b/src/server_input_handler.rs
@@ -455,9 +455,9 @@ pub fn handle_in_game(
         };
     }
     match cmd {
-        Commands::GetCurrentGamestate => return current_state(game),
-        Commands::MakeMove => return make_move(client_msg, game, client_id),
-        Commands::LeaveGame => return leave_game(&mut id_game_map_unlocked, client_id, game),
+        Commands::GetCurrentGamestate => current_state(game),
+        Commands::MakeMove => make_move(client_msg, game, client_id),
+        Commands::LeaveGame => leave_game(&mut id_game_map_unlocked, client_id, game),
         _ => Msg {
             status: Status::NotOk,
             headers: Headers::Read,


### PR DESCRIPTION
added the ability for the server to handle clients disconnecting at any time (in game or out of game) and manage the game state accordingly.

Now the server will "kick" the clients out of the game they disconnected from and ensure that any remaining players are reverted to the "waiting for another player" stage, with the board reset.  If a game is not full but it is created, it is listed as "available".

addresses #22 